### PR TITLE
removed CNAME file

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-https://neeraj1909.github.io/


### PR DESCRIPTION
There was an error that the page build completed successfully, but returned the following warning for the `master` branch:

The CNAME `neeraj1909.github.io/` is not properly formatted. See https://help.github.com/articles/troubleshooting-custom-domains/#github-repository-setup-errors for more information.

For information on troubleshooting Jekyll see:

  https://help.github.com/articles/troubleshooting-jekyll-builds

If you have any questions you can contact us by replying to this email.
